### PR TITLE
Fix clippy lints

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -24,21 +24,21 @@ fn init_benchmark(c: &mut Criterion) {
 }
 
 fn load_soccar_benchmark(c: &mut Criterion) {
-    c.bench_function("load_soccar", |b| b.iter(|| load_soccar()));
+    c.bench_function("load_soccar", |b| b.iter(load_soccar));
 }
 
 fn load_hoops_benchmark(c: &mut Criterion) {
-    c.bench_function("load_hoops", |b| b.iter(|| load_hoops()));
+    c.bench_function("load_hoops", |b| b.iter(load_hoops));
 }
 
 fn load_dropshot_benchmark(c: &mut Criterion) {
-    c.bench_function("load_dropshot", |b| b.iter(|| load_dropshot()));
+    c.bench_function("load_dropshot", |b| b.iter(load_dropshot));
 }
 
 // Disabled for now. This test spams the console with warnings and makes the benchmark output difficult to read
 #[allow(unused)]
 fn load_soccar_throwback_benchmark(c: &mut Criterion) {
-    c.bench_function("load_soccar_throwback", |b| b.iter(|| load_soccar_throwback()));
+    c.bench_function("load_soccar_throwback", |b| b.iter(load_soccar_throwback));
 }
 
 fn basic_predict_benchmark(c: &mut Criterion) {
@@ -47,8 +47,8 @@ fn basic_predict_benchmark(c: &mut Criterion) {
 
     game.ball.update(
         0.098145,
-        Vec3::new(-2294.524658, 1684.135986, 317.176727),
-        Vec3::new(1273.753662, -39.792305, 763.282715),
+        Vec3::new(-2294.5247, 1684.136, 317.17673),
+        Vec3::new(1273.7537, -39.792305, 763.2827),
         Vec3::new(2.3894, -0.8755, 3.8078),
     );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ use simulation::game::Game;
 use simulation::mesh::Mesh;
 use vvec3::Vec3;
 
+use crate::simulation::field::InitializeThrowbackParams;
+
 fn read_mesh(ids_dat: Vec<u8>, vertices_dat: Vec<u8>) -> Mesh {
     let mut ids_dat = Cursor::new(ids_dat);
     let mut vertices_dat = Cursor::new(vertices_dat);
@@ -115,7 +117,19 @@ pub fn load_soccar_throwback() -> Game {
     let side_ramps_lower: Mesh = read_mesh(include_bytes!("../assets/throwback/throwback_side_ramps_lower_ids.bin").to_vec(), include_bytes!("../assets/throwback/throwback_side_ramps_lower_vertices.bin").to_vec());
     let side_ramps_upper: Mesh = read_mesh(include_bytes!("../assets/throwback/throwback_side_ramps_upper_ids.bin").to_vec(), include_bytes!("../assets/throwback/throwback_side_ramps_upper_vertices.bin").to_vec());
 
-    let collision_mesh = initialize_throwback(&back_ramps_lower, &back_ramps_upper, &corner_ramps_lower, &corner_ramps_upper, &corner_wall_0, &corner_wall_1, &corner_wall_2, &goal, &side_ramps_lower, &side_ramps_upper);
+    let params = InitializeThrowbackParams {
+        back_ramps_lower: &back_ramps_lower,
+        back_ramps_upper: &back_ramps_upper,
+        corner_ramps_lower: &corner_ramps_lower,
+        corner_ramps_upper: &corner_ramps_upper,
+        corner_wall_0: &corner_wall_0,
+        corner_wall_1: &corner_wall_1,
+        corner_wall_2: &corner_wall_2,
+        goal: &goal,
+        side_ramps_lower: &side_ramps_lower,
+        side_ramps_upper: &side_ramps_upper,
+    };
+    let collision_mesh = initialize_throwback(params);
 
     let ball = Ball::initialize_soccar();
 

--- a/src/simulation/ball.rs
+++ b/src/simulation/ball.rs
@@ -66,27 +66,36 @@ impl Ball {
     const STANDARD_NUM_SLICES: usize = 720;
 
     pub fn initialize_soccar() -> Self {
-        let mut ball = Ball::default();
-        ball.radius = Ball::SOCCAR_RADIUS;
-        ball.collision_radius = Ball::SOCCAR_COLLISION_RADIUS;
+        let mut ball = Ball {
+            radius: Ball::SOCCAR_RADIUS,
+            collision_radius: Ball::SOCCAR_COLLISION_RADIUS,
+            ..Default::default()
+        };
+
         ball.initialize();
 
         ball
     }
 
     pub fn initialize_hoops() -> Self {
-        let mut ball = Ball::default();
-        ball.radius = Ball::HOOPS_RADIUS;
-        ball.collision_radius = Ball::HOOPS_COLLISION_RADIUS;
+        let mut ball = Ball {
+            radius: Ball::HOOPS_RADIUS,
+            collision_radius: Ball::HOOPS_COLLISION_RADIUS,
+            ..Default::default()
+        };
+
         ball.initialize();
 
         ball
     }
 
     pub fn initialize_dropshot() -> Self {
-        let mut ball = Ball::default();
-        ball.radius = Ball::DROPSHOT_RADIUS;
-        ball.collision_radius = Ball::DROPSHOT_COLLISION_RADIUS;
+        let mut ball = Ball {
+            radius: Ball::DROPSHOT_RADIUS,
+            collision_radius: Ball::DROPSHOT_COLLISION_RADIUS,
+            ..Default::default()
+        };
+
         ball.initialize();
 
         ball
@@ -110,8 +119,8 @@ impl Ball {
 
     fn hitbox(&self) -> Sphere {
         Sphere {
-            center: self.location.clone(),
-            radius: self.collision_radius.clone(),
+            center: self.location,
+            radius: self.collision_radius,
         }
     }
 
@@ -168,7 +177,7 @@ impl Ball {
 
         for _ in 0..Ball::STANDARD_NUM_SLICES {
             Ball::step(game, Ball::SIMULATION_DT);
-            slices.push(game.ball.clone());
+            slices.push(game.ball);
         }
 
         BallPrediction {

--- a/src/simulation/field.rs
+++ b/src/simulation/field.rs
@@ -1,3 +1,5 @@
+use std::f32::consts::{FRAC_PI_3, FRAC_PI_6};
+
 use super::bvh::Bvh;
 use super::mesh::Mesh;
 use crate::linear_algebra::mat::Mat3;
@@ -46,9 +48,7 @@ pub fn initialize_soccar(soccar_corner: &Mesh, soccar_goal: &Mesh, soccar_ramps_
     ]);
 
     let triangles = field_mesh.to_triangles();
-    let collision_mesh = Bvh::from(&triangles);
-
-    collision_mesh
+    Bvh::from(&triangles)
 }
 
 pub fn initialize_hoops(hoops_corner: &Mesh, hoops_net: &Mesh, hoops_rim: &Mesh, hoops_ramps_0: &Mesh, hoops_ramps_1: &Mesh) -> Bvh {
@@ -73,7 +73,7 @@ pub fn initialize_hoops(hoops_corner: &Mesh, hoops_net: &Mesh, hoops_rim: &Mesh,
     let back_walls = [quad(Vec3::new(0., 0., 1024.), Vec3::new(0., -5120., 0.), Vec3::new(0., 0., 1024.)), quad(Vec3::new(0., 0., 1024.), Vec3::new(0., 5120., 0.), Vec3::new(0., 0., 1024.))];
 
     let field_mesh = Mesh::from(vec![
-        &hoops_corner,
+        hoops_corner,
         &hoops_corner.transform(&FLIP_X),
         &hoops_corner.transform(&FLIP_Y),
         &hoops_corner.transform(&FLIP_X.dot(&FLIP_Y)),
@@ -81,9 +81,9 @@ pub fn initialize_hoops(hoops_corner: &Mesh, hoops_net: &Mesh, hoops_rim: &Mesh,
         &transformed_hoops_net.transform(&FLIP_Y),
         &transformed_hoops_rim,
         &transformed_hoops_rim.transform(&FLIP_Y),
-        &hoops_ramps_0,
+        hoops_ramps_0,
         &hoops_ramps_0.transform(&FLIP_X),
-        &hoops_ramps_1,
+        hoops_ramps_1,
         &hoops_ramps_1.transform(&FLIP_Y),
         &floor,
         &ceiling,
@@ -94,16 +94,16 @@ pub fn initialize_hoops(hoops_corner: &Mesh, hoops_net: &Mesh, hoops_rim: &Mesh,
     ]);
 
     let triangles = field_mesh.to_triangles();
-    let collision_mesh = Bvh::from(&triangles);
 
-    collision_mesh
+    Bvh::from(&triangles)
 }
 
+#[allow(clippy::many_single_char_names)]
 pub fn initialize_dropshot(dropshot: &Mesh) -> Bvh {
     let scale = 0.393;
     let z_offset = -207.565;
 
-    let q = axis_to_rotation(Vec3::new(0., 0., 0.52359877559));
+    let q = axis_to_rotation(Vec3::new(0., 0., FRAC_PI_6));
 
     let s = Mat3 {
         m: [[scale, 0., 0.], [0., scale, 0.], [0., 0., scale]],
@@ -118,7 +118,7 @@ pub fn initialize_dropshot(dropshot: &Mesh) -> Bvh {
     let mut p = Vec3::new(0., 11683.6 * scale, 2768.64 * scale - z_offset);
     let mut x = Vec3::new(5000., 0., 0.);
     let z = Vec3::new(0., 0., 1010.);
-    let r = axis_to_rotation(Vec3::new(0., 0., 1.047197551196598));
+    let r = axis_to_rotation(Vec3::new(0., 0., FRAC_PI_3));
 
     for _ in 0..6 {
         walls.push(quad(p, x, z));
@@ -129,12 +129,37 @@ pub fn initialize_dropshot(dropshot: &Mesh) -> Bvh {
     let field_mesh = Mesh::from(vec![&dropshot.transform(&q.dot(&s)).translate(&dz), &floor, &ceiling, &walls[0], &walls[1], &walls[2], &walls[3], &walls[4], &walls[5]]);
 
     let triangles = field_mesh.to_triangles();
-    let collision_mesh = Bvh::from(&triangles);
 
-    collision_mesh
+    Bvh::from(&triangles)
 }
 
-pub fn initialize_throwback(back_ramps_lower: &Mesh, back_ramps_upper: &Mesh, corner_ramps_lower: &Mesh, corner_ramps_upper: &Mesh, corner_wall_0: &Mesh, corner_wall_1: &Mesh, corner_wall_2: &Mesh, goal: &Mesh, side_ramps_lower: &Mesh, side_ramps_upper: &Mesh) -> Bvh {
+pub struct InitializeThrowbackParams<'a> {
+    pub back_ramps_lower: &'a Mesh,
+    pub back_ramps_upper: &'a Mesh,
+    pub corner_ramps_lower: &'a Mesh,
+    pub corner_ramps_upper: &'a Mesh,
+    pub corner_wall_0: &'a Mesh,
+    pub corner_wall_1: &'a Mesh,
+    pub corner_wall_2: &'a Mesh,
+    pub goal: &'a Mesh,
+    pub side_ramps_lower: &'a Mesh,
+    pub side_ramps_upper: &'a Mesh,
+}
+
+pub fn initialize_throwback(
+    InitializeThrowbackParams {
+        back_ramps_lower,
+        back_ramps_upper,
+        corner_ramps_lower,
+        corner_ramps_upper,
+        corner_wall_0,
+        corner_wall_1,
+        corner_wall_2,
+        goal,
+        side_ramps_lower,
+        side_ramps_upper,
+    }: InitializeThrowbackParams<'_>,
+) -> Bvh {
     let scale = 100.;
 
     let s = Mat3 {
@@ -203,7 +228,6 @@ pub fn initialize_throwback(back_ramps_lower: &Mesh, back_ramps_upper: &Mesh, co
     ]);
 
     let triangles = field_mesh.to_triangles();
-    let collision_mesh = Bvh::from(&triangles);
 
-    collision_mesh
+    Bvh::from(&triangles)
 }

--- a/src/simulation/geometry.rs
+++ b/src/simulation/geometry.rs
@@ -21,6 +21,7 @@ impl Tri {
         (self.p[1] - self.p[0]).cross(&(self.p[2] - self.p[0])).normalize()
     }
 
+    #[allow(clippy::many_single_char_names)]
     pub fn intersect_sphere(&self, b: &Sphere) -> bool {
         let mut _dist = 0.;
 
@@ -46,7 +47,7 @@ impl Tri {
         // the out-of-plane distance
         // otherwise, check the distances to
         // the closest edge of the triangle
-        if 0. <= u && u <= 1. && 0. <= v && v <= 1. && 0. <= w && w <= 1. {
+        if (0. ..=1.).contains(&u) && (0. ..=1.).contains(&v) && (0. ..=1.).contains(&w) {
             _dist = z.abs();
         } else {
             _dist = b.radius + 1.;

--- a/src/simulation/mesh.rs
+++ b/src/simulation/mesh.rs
@@ -86,6 +86,7 @@ impl Mesh {
         }
     }
 
+    #[rustfmt::skip]
     pub fn transform(&self, a: &Mat3) -> Self {
         let mut ids: Vec<i32> = self.ids.clone();
         let mut vertices: Vec<f32> = self.vertices.clone();
@@ -93,9 +94,9 @@ impl Mesh {
         let n = self.vertices.len() / 3;
 
         for i in 0..n {
-            let v = dot(&a, &Vec3::new(self.vertices[i * 3 + 0] as f32, self.vertices[i * 3 + 1] as f32, self.vertices[i * 3 + 2] as f32));
+            let v = dot(a, &Vec3::new(self.vertices[i * 3    ] as f32, self.vertices[i * 3 + 1] as f32, self.vertices[i * 3 + 2] as f32));
 
-            vertices[i * 3 + 0] = v.x as f32;
+            vertices[i * 3    ] = v.x as f32;
             vertices[i * 3 + 1] = v.y as f32;
             vertices[i * 3 + 2] = v.z as f32;
         }
@@ -105,8 +106,8 @@ impl Mesh {
         if a.det() < 0 as f32 {
             let n = ids.len() / 3;
             for i in 0..n {
-                ids[i * 3 + 0] = self.ids[i * 3 + 1];
-                ids[i * 3 + 1] = self.ids[i * 3 + 0];
+                ids[i * 3    ] = self.ids[i * 3 + 1];
+                ids[i * 3 + 1] = self.ids[i * 3    ];
                 ids[i * 3 + 2] = self.ids[i * 3 + 2];
             }
         }
@@ -117,13 +118,14 @@ impl Mesh {
         }
     }
 
+    #[rustfmt::skip]
     pub fn translate(&self, p: &Vec3) -> Self {
         let ids: Vec<i32> = self.ids.clone();
         let mut vertices: Vec<f32> = self.vertices.clone();
 
         let n = vertices.len() / 3;
         for i in 0..n {
-            vertices[i * 3 + 0] += p.x as f32;
+            vertices[i * 3    ] += p.x as f32;
             vertices[i * 3 + 1] += p.y as f32;
             vertices[i * 3 + 2] += p.z as f32;
         }
@@ -134,6 +136,7 @@ impl Mesh {
         }
     }
 
+    #[rustfmt::skip]
     pub fn to_triangles(&self) -> Vec<Tri> {
         let n = self.ids.len() / 3;
         let mut triangles: Vec<Tri> = Vec::with_capacity(n);
@@ -142,7 +145,7 @@ impl Mesh {
             triangles.push(Tri::default());
             for j in 0..3 {
                 let id = (self.ids[i * 3 + j] * 3) as usize;
-                triangles[i].p[j].x = self.vertices[id + 0] as f32;
+                triangles[i].p[j].x = self.vertices[id    ] as f32;
                 triangles[i].p[j].y = self.vertices[id + 1] as f32;
                 triangles[i].p[j].z = self.vertices[id + 2] as f32;
             }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -78,7 +78,7 @@ fn gamemode_soccar() {
 
     dbg!(game.collision_mesh.root.box_);
 
-    assert_eq!(game.collision_mesh.num_leaves, 8028 as u64);
+    assert_eq!(game.collision_mesh.num_leaves, 8028u64);
 
     assert_eq!(game.ball.time as i64, 0);
     assert_eq!(game.ball.location.x as i64, 0);
@@ -106,7 +106,7 @@ fn gamemode_hoops() {
 
     dbg!(game.collision_mesh.root.box_);
 
-    assert_eq!(game.collision_mesh.num_leaves, 15732 as u64);
+    assert_eq!(game.collision_mesh.num_leaves, 15732u64);
 
     assert_eq!(game.ball.time as i64, 0);
     assert_eq!(game.ball.location.x as i64, 0);
@@ -134,7 +134,7 @@ fn gamemode_dropshot() {
 
     dbg!(game.collision_mesh.root.box_);
 
-    assert_eq!(game.collision_mesh.num_leaves, 3616 as u64);
+    assert_eq!(game.collision_mesh.num_leaves, 3616u64);
 
     assert_eq!(game.ball.time as i64, 0);
     assert_eq!(game.ball.location.x as i64, 0);
@@ -197,7 +197,7 @@ fn basic_predict() {
     assert_eq!(game.ball.radius as i64, 91);
     assert_eq!(game.ball.collision_radius as i64, 93);
 
-    game.ball.update(0.098145, Vec3::new(-2294.524658, 1684.135986, 317.176727), Vec3::new(1273.753662, -39.792305, 763.282715), Vec3::new(2.3894, -0.8755, 3.8078));
+    game.ball.update(0.098145, Vec3::new(-2294.5247, 1684.136, 317.17673), Vec3::new(1273.7537, -39.792305, 763.2827), Vec3::new(2.3894, -0.8755, 3.8078));
 
     let time = 60.; // 1 minute, lol
     let ball_prediction = Ball::get_ball_prediction_struct_for_time(&mut game, &time);


### PR DESCRIPTION
Fixes a bunch of clippy lints. Most are pretty simple.

Disabled the [`many_single_char_names`](https://rust-lang.github.io/rust-clippy/master/#many_single_char_names) lint for `initialize_dropshot()` and `Tri.intersect_sphere()`. These functions should use more descriptive names for their identifiers. I wasn't familiar enough with them to give them more descriptive identifiers.

Added `#[rustfmt::skip]` attribute to `Mesh.transform()`, `Mesh.translate()` and `Mesh.to_triangles()` to allow the `+ 0` to be removed from array indices, but preserve the formatting.