### PR TITLE
Use glam for vector math

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,15 @@ lazy_static = "1.4.0"
 
 [dependencies]
 byteorder = "1.*"
-vvec3 = "0.1.*"
+glam = "0.20.1"
 
 [profile.release]
-codegen-units=1
+codegen-units = 1
 lto = "fat"
 panic = "abort"
 
 [profile.bench]
-codegen-units=1
+codegen-units = 1
 lto = "fat"
 
 [[bench]]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
+use glam::{Vec3A, vec3a};
 use rl_ball_sym::load_soccar;
 use rl_ball_sym::simulation::ball::{Ball, BallPrediction};
 use rl_ball_sym::simulation::game::Game;
-use vvec3::Vec3;
 
 use rand::Rng;
 
@@ -13,12 +13,12 @@ pub fn main() {
 
     // simulate our get_output function being called for 2 seconds - you can pretty much just ignore this.
     for _ in 0..240 {
-        get_output(Vec3::new(rng.gen_range(-4000.0..4000.), rng.gen_range(-5020.0..5020.), rng.gen_range(0.0..1944.)), Vec3::new(rng.gen_range(-2000.0..2000.), rng.gen_range(-2000.0..2000.), rng.gen_range(-2000.0..2000.)), Vec3::new(rng.gen_range(-3.0..3.), rng.gen_range(-3.0..3.), rng.gen_range(-3.0..3.)), time);
+        get_output(vec3a(rng.gen_range(-4000.0..4000.), rng.gen_range(-5020.0..5020.), rng.gen_range(0.0..1944.)), vec3a(rng.gen_range(-2000.0..2000.), rng.gen_range(-2000.0..2000.), rng.gen_range(-2000.0..2000.)), vec3a(rng.gen_range(-3.0..3.), rng.gen_range(-3.0..3.), rng.gen_range(-3.0..3.)), time);
         time += 1. / 120.;
     }
 }
 
-fn get_output(ball_location: Vec3, ball_velocity: Vec3, ball_angular_velocity: Vec3, time: f32) {
+fn get_output(ball_location: Vec3A, ball_velocity: Vec3A, ball_angular_velocity: Vec3A, time: f32) {
     let game: &mut Game;
 
     unsafe {

--- a/examples/custom_time.rs
+++ b/examples/custom_time.rs
@@ -1,7 +1,7 @@
+use glam::{vec3a, Vec3A};
 use rl_ball_sym::load_soccar;
 use rl_ball_sym::simulation::ball::{Ball, BallPrediction};
 use rl_ball_sym::simulation::game::Game;
-use vvec3::Vec3;
 
 use rand::Rng;
 
@@ -13,12 +13,12 @@ pub fn main() {
 
     // simulate our get_output function being called for 2 seconds - you can pretty much just ignore this.
     for _ in 0..240 {
-        get_output(Vec3::new(rng.gen_range(-4000.0..4000.), rng.gen_range(-5020.0..5020.), rng.gen_range(0.0..1944.)), Vec3::new(rng.gen_range(-2000.0..2000.), rng.gen_range(-2000.0..2000.), rng.gen_range(-2000.0..2000.)), Vec3::new(rng.gen_range(-3.0..3.), rng.gen_range(-3.0..3.), rng.gen_range(-3.0..3.)), time);
+        get_output(vec3a(rng.gen_range(-4000.0..4000.), rng.gen_range(-5020.0..5020.), rng.gen_range(0.0..1944.)), vec3a(rng.gen_range(-2000.0..2000.), rng.gen_range(-2000.0..2000.), rng.gen_range(-2000.0..2000.)), vec3a(rng.gen_range(-3.0..3.), rng.gen_range(-3.0..3.), rng.gen_range(-3.0..3.)), time);
         time += 1. / 120.;
     }
 }
 
-fn get_output(ball_location: Vec3, ball_velocity: Vec3, ball_angular_velocity: Vec3, time: f32) {
+fn get_output(ball_location: Vec3A, ball_velocity: Vec3A, ball_angular_velocity: Vec3A, time: f32) {
     let game: &mut Game;
 
     unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,11 @@ use std::io::{Cursor, ErrorKind};
 pub mod linear_algebra;
 pub mod simulation;
 
+use glam::{vec3a};
 use simulation::ball::Ball;
 use simulation::field::{initialize_dropshot, initialize_hoops, initialize_soccar, initialize_throwback};
 use simulation::game::Game;
 use simulation::mesh::Mesh;
-use vvec3::Vec3;
 
 use crate::simulation::field::InitializeThrowbackParams;
 
@@ -58,7 +58,7 @@ pub fn load_soccar() -> Game {
 
     let ball = Ball::initialize_soccar();
 
-    let gravity = Vec3::new(0., 0., -650.);
+    let gravity = vec3a(0., 0., -650.);
 
     Game {
         gravity,
@@ -78,7 +78,7 @@ pub fn load_hoops() -> Game {
 
     let ball = Ball::initialize_hoops();
 
-    let gravity = Vec3::new(0., 0., -650.);
+    let gravity = vec3a(0., 0., -650.);
 
     Game {
         gravity,
@@ -94,7 +94,7 @@ pub fn load_dropshot() -> Game {
 
     let ball = Ball::initialize_dropshot();
 
-    let gravity = Vec3::new(0., 0., -650.);
+    let gravity = vec3a(0., 0., -650.);
 
     Game {
         gravity,
@@ -133,7 +133,7 @@ pub fn load_soccar_throwback() -> Game {
 
     let ball = Ball::initialize_soccar();
 
-    let gravity = Vec3::new(0., 0., -650.);
+    let gravity = vec3a(0., 0., -650.);
 
     Game {
         gravity,

--- a/src/linear_algebra/mat.rs
+++ b/src/linear_algebra/mat.rs
@@ -1,51 +1,31 @@
-#[derive(Clone, Copy, Debug)]
-pub struct Mat3 {
-    pub m: [[f32; 3]; 3],
+use glam::Mat3A;
+
+pub(crate) trait MatrixExt {
+    fn dot(&self, other: Self) -> Self;
 }
 
-impl Default for Mat3 {
-    fn default() -> Self {
-        Self {
-            m: [[0.; 3]; 3],
-        }
+impl MatrixExt for Mat3A {
+    fn dot(&self, other: Self) -> Self {
+        // For some reason, glam does matrix multiplication in column order. So,
+        // we have to transpose both matrices prior to multiplying them. Then,
+        // transpose the final result.
+        (self.transpose() * other.transpose()).transpose()
     }
 }
 
-impl Mat3 {
-    pub fn eye() -> Mat3 {
-        Mat3 {
-            m: [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]],
-        }
-    }
+#[cfg(test)]
+mod test {
 
-    pub fn det(self) -> f32 {
-        self.m[0][0] * self.m[1][1] * self.m[2][2] + self.m[0][1] * self.m[1][2] * self.m[2][0] + self.m[0][2] * self.m[1][0] * self.m[2][1] - self.m[0][0] * self.m[1][2] * self.m[2][1] - self.m[0][1] * self.m[1][0] * self.m[2][2] - self.m[0][2] * self.m[1][1] * self.m[2][0]
-    }
+    use glam::{const_mat3a, Mat3A};
 
-    pub fn dot(self, b: Mat3) -> Mat3 {
-        let mut c: Mat3 = Mat3::default();
+    use crate::linear_algebra::mat::MatrixExt;
 
-        for i in 0..3 {
-            for j in 0..3 {
-                c.m[i][j] = 0.;
-                for k in 0..3 {
-                    c.m[i][j] += self.m[i][k] * b.m[k][j];
-                }
-            }
-        }
+    const A: Mat3A = const_mat3a!([-1., 2., 3.], [4., 5., 6.], [7., 8., 9.]);
+    const B: Mat3A = const_mat3a!([9., 8., 7.], [6., -5., 4.], [3., 2., 1.]);
+    const C: Mat3A = const_mat3a!([12.0, -12.0, 4.0], [84.0, 19.0, 54.0], [138.0, 34.0, 90.0]);
 
-        c
-    }
-
-    pub fn inv(self) -> Mat3 {
-        let inv_det_a = 1. / self.det();
-
-        Self {
-            m: [
-                [(self.m[1][1] * self.m[2][2] - self.m[1][2] * self.m[2][1]) * inv_det_a, (self.m[0][2] * self.m[2][1] - self.m[0][1] * self.m[2][2]) * inv_det_a, (self.m[0][1] * self.m[1][2] - self.m[0][2] * self.m[1][1]) * inv_det_a],
-                [(self.m[1][2] * self.m[2][0] - self.m[1][0] * self.m[2][2]) * inv_det_a, (self.m[0][0] * self.m[2][2] - self.m[0][2] * self.m[2][0]) * inv_det_a, (self.m[0][2] * self.m[1][0] - self.m[0][0] * self.m[1][2]) * inv_det_a],
-                [(self.m[1][0] * self.m[2][1] - self.m[1][1] * self.m[2][0]) * inv_det_a, (self.m[0][1] * self.m[2][0] - self.m[0][0] * self.m[2][1]) * inv_det_a, (self.m[0][0] * self.m[1][1] - self.m[0][1] * self.m[1][0]) * inv_det_a],
-            ],
-        }
+    #[test]
+    fn mat3_dot() {
+        assert_eq!(A.dot(B), C);
     }
 }

--- a/src/linear_algebra/math.rs
+++ b/src/linear_algebra/math.rs
@@ -1,22 +1,28 @@
-use super::mat::Mat3;
-use vvec3::Vec3;
+use glam::{Mat3A, Vec3A};
 
-pub fn axis_to_rotation(vec: Vec3) -> Mat3 {
-    let norm_omega = vec.magnitude();
+pub fn axis_to_rotation(axis: Vec3A) -> Mat3A {
+    let angle = axis.length();
 
-    if norm_omega.abs() < 0.000001 {
-        return Mat3::eye();
-    }
-    let u = vec / norm_omega;
-
-    let c = norm_omega.cos();
-    let s = norm_omega.sin();
-
-    Mat3 {
-        m: [[u.x * u.x * (1. - c) + c, u.x * u.y * (1. - c) - u.z * s, u.x * u.z * (1. - c) + u.y * s], [u.y * u.x * (1. - c) + u.z * s, u.y * u.y * (1. - c) + c, u.y * u.z * (1. - c) - u.x * s], [u.y * u.x * (1. - c) - u.y * s, u.y * u.y * (1. - c) + u.x * s, u.y * u.z * (1. - c) + c]],
-    }
+    Mat3A::from_axis_angle(axis.into(), angle)
 }
 
-pub fn dot(a: Mat3, v: Vec3) -> Vec3 {
-    Vec3::new(a.m[0][0] * v.x + a.m[0][1] * v.y + a.m[0][2] * v.z, a.m[1][0] * v.x + a.m[1][1] * v.y + a.m[1][2] * v.z, a.m[2][0] * v.x + a.m[2][1] * v.y + a.m[2][2] * v.z)
+pub fn dot(matrix: Mat3A, vector: Vec3A) -> Vec3A {
+    matrix.transpose().mul_vec3a(vector)
+}
+
+#[cfg(test)]
+mod test {
+    use glam::{const_mat3a, const_vec3a, Mat3A, Vec3A};
+
+    use crate::linear_algebra::math::dot;
+
+    #[allow(clippy::approx_constant)]
+    const MAT: Mat3A = const_mat3a!([-0.0, -0.16666667, -0.16666667], [0.16666667, 0.083333336, 0.083333336], [0.0, -0.7071068, 0.7071068]);
+    const VEC: Vec3A = const_vec3a!([3., -1., -1.]);
+    const RES: Vec3A = const_vec3a!([0.33333334, 0.3333333, 0.0]);
+
+    #[test]
+    fn test_dot() {
+        assert_eq!(dot(MAT, VEC), RES);
+    }
 }

--- a/src/simulation/bvh.rs
+++ b/src/simulation/bvh.rs
@@ -84,7 +84,7 @@ impl Bvh {
 
         let mut boxes: Vec<Aabb> = Vec::with_capacity(num_leaves);
         for primitive in primitives {
-            boxes.push(Aabb::from_tri(primitive));
+            boxes.push(primitive.into());
         }
 
         let global_box = global_aabb(&boxes);
@@ -126,7 +126,7 @@ impl Bvh {
     }
 
     pub fn intersect(&self, query_object: &Sphere) -> Vec<Tri> {
-        let query_box: Aabb = Aabb::from_sphere(query_object);
+        let query_box: Aabb = query_object.into();
 
         let mut hits = Vec::with_capacity(16);
 
@@ -202,7 +202,7 @@ impl Bvh {
             let p = tri.center();
             let n = tri.unit_normal();
 
-            let separation = (s.center - p).dot(&n);
+            let separation = (s.center - p).dot(n);
             if separation <= s.radius {
                 count += 1;
                 contact_point.start += s.center - n * separation;
@@ -224,7 +224,7 @@ impl Bvh {
 #[cfg(test)]
 mod test {
     use criterion::black_box;
-    use vvec3::Vec3;
+    use glam::{vec3a, Vec3A};
 
     use super::*;
 
@@ -239,28 +239,28 @@ mod test {
     fn global_bounding_box() {
         let bounding_boxes = vec![
             Aabb {
-                min: Vec3::new(MIN_X, 0.0, 0.0),
-                max: Vec3::new(0.0, 0.0, 0.0),
+                min: vec3a(MIN_X, 0.0, 0.0),
+                max: Vec3A::ZERO,
             },
             Aabb {
-                min: Vec3::new(0.0, MIN_Y, 0.0),
-                max: Vec3::new(0.0, 0.0, 0.0),
+                min: vec3a(0.0, MIN_Y, 0.0),
+                max: Vec3A::ZERO,
             },
             Aabb {
-                min: Vec3::new(0.0, 0.0, MIN_Z),
-                max: Vec3::new(0.0, 0.0, 0.0),
+                min: vec3a(0.0, 0.0, MIN_Z),
+                max: Vec3A::ZERO,
             },
             Aabb {
-                min: Vec3::new(0.0, 0.0, 0.0),
-                max: Vec3::new(MAX_X, 0.0, 0.0),
+                min: Vec3A::ZERO,
+                max: vec3a(MAX_X, 0.0, 0.0),
             },
             Aabb {
-                min: Vec3::new(0.0, 0.0, 0.0),
-                max: Vec3::new(0.0, MAX_Y, 0.0),
+                min: Vec3A::ZERO,
+                max: vec3a(0.0, MAX_Y, 0.0),
             },
             Aabb {
-                min: Vec3::new(0.0, 0.0, 0.0),
-                max: Vec3::new(0.0, 0.0, MAX_Z),
+                min: Vec3A::ZERO,
+                max: vec3a(0.0, 0.0, MAX_Z),
             },
         ];
 
@@ -278,12 +278,12 @@ mod test {
     fn global_bounding_box_min() {
         let bounding_boxes = vec![
             Aabb {
-                min: Vec3::new(MIN_X, MIN_Y, MIN_Z),
-                max: Vec3::new(MIN_X, MIN_Y, MIN_Z),
+                min: vec3a(MIN_X, MIN_Y, MIN_Z),
+                max: vec3a(MIN_X, MIN_Y, MIN_Z),
             },
             Aabb {
-                min: Vec3::new(MIN_X, MIN_Y, MIN_Z),
-                max: Vec3::new(MIN_X, MIN_Y, MIN_Z),
+                min: vec3a(MIN_X, MIN_Y, MIN_Z),
+                max: vec3a(MIN_X, MIN_Y, MIN_Z),
             },
         ];
         let global = global_aabb(&bounding_boxes);
@@ -300,12 +300,12 @@ mod test {
     fn global_bounding_box_max() {
         let bounding_boxes = vec![
             Aabb {
-                min: Vec3::new(MAX_X, MAX_Y, MAX_Z),
-                max: Vec3::new(MAX_X, MAX_Y, MAX_Z),
+                min: vec3a(MAX_X, MAX_Y, MAX_Z),
+                max: vec3a(MAX_X, MAX_Y, MAX_Z),
             },
             Aabb {
-                min: Vec3::new(MAX_X, MAX_Y, MAX_Z),
-                max: Vec3::new(MAX_X, MAX_Y, MAX_Z),
+                min: vec3a(MAX_X, MAX_Y, MAX_Z),
+                max: vec3a(MAX_X, MAX_Y, MAX_Z),
             },
         ];
         let global = global_aabb(&bounding_boxes);
@@ -321,7 +321,7 @@ mod test {
     static VERT_MAP: &[[usize; 3]; 12] = &[[1, 0, 2], [3, 1, 2], [7, 5, 6], [4, 6, 5], [2, 0, 4], [6, 2, 4], [7, 3, 5], [1, 5, 3], [4, 0, 1], [5, 4, 1], [7, 6, 3], [2, 3, 6]];
 
     fn generate_tris() -> Vec<Tri> {
-        let verts = &[Vec3::new(-4096.0, -5120.0, 0.0), Vec3::new(-4096.0, -5120.0, 2044.0), Vec3::new(-4096.0, 5120.0, 0.0), Vec3::new(-4096.0, 5120.0, 2044.0), Vec3::new(4096.0, -5120.0, 0.0), Vec3::new(4096.0, -5120.0, 2044.0), Vec3::new(4096.0, 5120.0, 0.0), Vec3::new(4096.0, 5120.0, 2044.0)];
+        let verts = &[vec3a(-4096.0, -5120.0, 0.0), vec3a(-4096.0, -5120.0, 2044.0), vec3a(-4096.0, 5120.0, 0.0), vec3a(-4096.0, 5120.0, 2044.0), vec3a(4096.0, -5120.0, 0.0), vec3a(4096.0, -5120.0, 2044.0), vec3a(4096.0, 5120.0, 0.0), vec3a(4096.0, 5120.0, 2044.0)];
         VERT_MAP
             .iter()
             .map(|map| {
@@ -348,7 +348,7 @@ mod test {
         {
             // Sphere hits nothing
             let sphere = Sphere {
-                center: Vec3::new(0., 0., 1022.),
+                center: vec3a(0., 0., 1022.),
                 radius: 100.,
             };
             let hits = bvh.intersect(&sphere);
@@ -357,7 +357,7 @@ mod test {
         {
             // Sphere hits one Tri
             let sphere = Sphere {
-                center: Vec3::new(4096. / 2., 5120. / 2., 100.),
+                center: vec3a(4096. / 2., 5120. / 2., 100.),
                 radius: 100.,
             };
             let hits = bvh.intersect(&sphere);
@@ -379,7 +379,7 @@ mod test {
         {
             // Middle of two Tris
             let sphere = Sphere {
-                center: Vec3::new(0., 0., 0.),
+                center: Vec3A::ZERO,
                 radius: 100.,
             };
             let hits = bvh.intersect(&sphere);
@@ -389,7 +389,7 @@ mod test {
         {
             // Sphere is in a corner
             let sphere = Sphere {
-                center: Vec3::new(4096., 5120., 0.),
+                center: vec3a(4096., 5120., 0.),
                 radius: 100.,
             };
             let hits = bvh.intersect(&sphere);
@@ -407,7 +407,7 @@ mod test {
         {
             // Sphere hits nothing
             let sphere = Sphere {
-                center: Vec3::new(0., 0., 1022.),
+                center: vec3a(0., 0., 1022.),
                 radius: 100.,
             };
 
@@ -418,7 +418,7 @@ mod test {
         {
             // Sphere hits one Tri
             let sphere = Sphere {
-                center: Vec3::new(4096. / 2., 5120. / 2., 99.),
+                center: vec3a(4096. / 2., 5120. / 2., 99.),
                 radius: 100.,
             };
 
@@ -436,7 +436,7 @@ mod test {
         {
             // Middle of two Tris
             let sphere = Sphere {
-                center: Vec3::new(0., 0., 0.),
+                center: Vec3A::ZERO,
                 radius: 100.,
             };
 
@@ -454,7 +454,7 @@ mod test {
         {
             // Sphere is in a corner
             let sphere = Sphere {
-                center: Vec3::new(4096., 5120., 0.),
+                center: vec3a(4096., 5120., 0.),
                 radius: 100.,
             };
 
@@ -479,7 +479,7 @@ mod test {
 
         {
             let sphere = Sphere {
-                center: Vec3::new(0., 0., 93.15),
+                center: vec3a(0., 0., 93.15),
                 radius: 93.15,
             };
 
@@ -487,12 +487,8 @@ mod test {
 
             assert!(ray.is_some());
             let ray = ray.unwrap();
-            assert!(ray.direction.x.is_finite());
-            assert!(ray.direction.y.is_finite());
-            assert!(ray.direction.z.is_finite());
-            assert!(ray.start.x.is_finite());
-            assert!(ray.start.y.is_finite());
-            assert!(ray.start.z.is_finite());
+            assert!(ray.direction.is_finite());
+            assert!(ray.start.is_finite());
         }
     }
 }

--- a/src/simulation/bvh.rs
+++ b/src/simulation/bvh.rs
@@ -215,7 +215,7 @@ impl Bvh {
         }
 
         contact_point.start /= count as f32;
-        contact_point.direction = contact_point.direction.normalize();
+        contact_point.direction = contact_point.direction.normalize_or_zero();
 
         Some(contact_point)
     }

--- a/src/simulation/game.rs
+++ b/src/simulation/game.rs
@@ -1,10 +1,11 @@
+use glam::Vec3A;
+
 use super::ball::Ball;
 use super::bvh::Bvh;
-use vvec3::Vec3;
 
 #[derive(Clone)]
 pub struct Game {
-    pub gravity: Vec3,
+    pub gravity: Vec3A,
     pub collision_mesh: Bvh,
     pub ball: Ball,
 }
@@ -12,7 +13,7 @@ pub struct Game {
 impl Default for Game {
     fn default() -> Self {
         Self {
-            gravity: Vec3::default(),
+            gravity: Vec3A::default(),
             collision_mesh: Bvh::default(),
             ball: Ball::default(),
         }

--- a/src/simulation/geometry.rs
+++ b/src/simulation/geometry.rs
@@ -1,24 +1,23 @@
-use crate::linear_algebra::mat::Mat3;
 use crate::linear_algebra::math::dot;
-use vvec3::Vec3;
+use glam::{Mat3A, Vec3A};
 
-pub fn distance_between(start: &Vec3, dir: &Vec3, p: &Vec3) -> f32 {
-    let u = ((*p - *start).dot(dir) / dir.dot(dir)).clamp(0., 1.);
-    (*start + *dir * u - *p).magnitude()
+pub fn distance_between(start: Vec3A, dir: Vec3A, p: Vec3A) -> f32 {
+    let u = ((p - start).dot(dir) / dir.length_squared()).clamp(0., 1.);
+    (start + dir * u - p).length()
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Tri {
-    pub p: [Vec3; 3],
+    pub p: [Vec3A; 3],
 }
 
 impl Tri {
-    pub fn center(&self) -> Vec3 {
-        (self.p[0] + self.p[1] + self.p[2]) / 3.
+    pub fn center(&self) -> Vec3A {
+        self.p.iter().sum::<Vec3A>() / 3.
     }
 
-    pub fn unit_normal(&self) -> Vec3 {
-        (self.p[1] - self.p[0]).cross(&(self.p[2] - self.p[0])).normalize()
+    pub fn unit_normal(&self) -> Vec3A {
+        (self.p[1] - self.p[0]).cross(self.p[2] - self.p[0]).normalize()
     }
 
     #[allow(clippy::many_single_char_names)]
@@ -26,13 +25,10 @@ impl Tri {
         let e1 = self.p[1] - self.p[0];
         let e2 = self.p[2] - self.p[1];
         let e3 = self.p[0] - self.p[2];
-        let n = (&e3).cross(&e1).normalize();
+        let n = e3.cross(e1).normalize();
 
-        let a = Mat3 {
-            m: [[e1.x, -e3.x, n.x], [e1.y, -e3.y, n.y], [e1.z, -e3.z, n.z]],
-        };
-
-        let x = dot(a.inv(), b.center - self.p[0]);
+        let a = Mat3A::from_cols_array_2d(&[[e1.x, -e3.x, n.x], [e1.y, -e3.y, n.y], [e1.z, -e3.z, n.z]]);
+        let x = dot(a.inverse(), b.center - self.p[0]);
 
         let u = x.x;
         let v = x.y;
@@ -48,18 +44,10 @@ impl Tri {
         let dist = if (0. ..=1.).contains(&u) && (0. ..=1.).contains(&v) && (0. ..=1.).contains(&w) {
             z.abs()
         } else {
-            (b.radius + 1.).min(distance_between(&self.p[0], &e1, &b.center)).min(distance_between(&self.p[1], &e2, &b.center)).min(distance_between(&self.p[2], &e3, &b.center))
+            (b.radius + 1.).min(distance_between(self.p[0], e1, b.center)).min(distance_between(self.p[1], e2, b.center)).min(distance_between(self.p[2], e3, b.center))
         };
 
         dist <= b.radius
-    }
-}
-
-impl Default for Tri {
-    fn default() -> Self {
-        Self {
-            p: [Vec3::default(), Vec3::default(), Vec3::default()],
-        }
     }
 }
 
@@ -67,15 +55,15 @@ impl Default for Tri {
 // Learn more here: https://developer.nvidia.com/blog/thinking-parallel-part-i-collision-detection-gpu/
 #[derive(Clone, Copy, Debug)]
 pub struct Aabb {
-    pub min: Vec3,
-    pub max: Vec3,
+    pub min: Vec3A,
+    pub max: Vec3A,
 }
 
 impl Default for Aabb {
     fn default() -> Self {
         Self {
-            min: Vec3::default(),
-            max: Vec3::default(),
+            min: Vec3A::default(),
+            max: Vec3A::default(),
         }
     }
 }
@@ -83,14 +71,15 @@ impl Default for Aabb {
 impl Aabb {
     pub fn add(&self, b: &Aabb) -> Self {
         Self {
-            min: self.min.min(&b.min),
-            max: self.max.max(&b.max),
+            min: self.min.min(b.min),
+            max: self.max.max(b.max),
         }
     }
 
     pub fn from_tri(t: &Tri) -> Self {
-        let min = Vec3::new(t.p[0].x.min(t.p[1].x.min(t.p[2].x)), t.p[0].y.min(t.p[1].y.min(t.p[2].y)), t.p[0].z.min(t.p[1].z.min(t.p[2].z)));
-        let max = Vec3::new(t.p[0].x.max(t.p[1].x.max(t.p[2].x)), t.p[0].y.max(t.p[1].y.max(t.p[2].y)), t.p[0].z.max(t.p[1].z.max(t.p[2].z)));
+        let min = t.p.into_iter().reduce(Vec3A::min).expect("Tri points array empty?");
+
+        let max = t.p.into_iter().reduce(Vec3A::max).expect("Tri points array empty?");
 
         Self {
             min,
@@ -99,22 +88,32 @@ impl Aabb {
     }
 
     pub fn from_sphere(s: &Sphere) -> Self {
-        let radius = Vec3::new(s.radius, s.radius, s.radius);
-
         Self {
-            min: s.center - radius,
-            max: s.center + radius,
+            min: s.center - s.radius,
+            max: s.center + s.radius,
         }
     }
 
     pub fn intersect_self(&self, b: &Aabb) -> bool {
-        (self.min.x <= b.max.x) & (self.max.x >= b.min.x) & (self.min.y <= b.max.y) & (self.max.y >= b.min.y) & (self.min.z <= b.max.z) & (self.max.z >= b.min.z)
+        self.min.cmple(b.max).all() && self.max.cmpge(b.min).all()
     }
 
     pub fn intersect_sphere(&self, b: &Sphere) -> bool {
-        let nearest = Vec3::new(b.center.x.clamp(self.min.x, self.max.x), b.center.y.clamp(self.min.y, self.max.y), b.center.z.clamp(self.min.z, self.max.z));
+        let nearest = b.center.clamp(self.min, self.max);
 
-        (b.center - nearest).magnitude() <= b.radius
+        (b.center - nearest).length() <= b.radius
+    }
+}
+
+impl From<&'_ Tri> for Aabb {
+    fn from(value: &'_ Tri) -> Self {
+        Aabb::from_tri(value)
+    }
+}
+
+impl From<&'_ Sphere> for Aabb {
+    fn from(value: &'_ Sphere) -> Self {
+        Aabb::from_sphere(value)
     }
 }
 
@@ -134,177 +133,154 @@ impl Default for Int2 {
 }
 
 // endpoint is start + direction
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Ray {
-    pub start: Vec3,
-    pub direction: Vec3,
-}
-
-impl Default for Ray {
-    fn default() -> Self {
-        Self {
-            start: Vec3::default(),
-            direction: Vec3::default(),
-        }
-    }
+    pub start: Vec3A,
+    pub direction: Vec3A,
 }
 
 #[derive(Clone, Copy, Debug)]
 pub struct Sphere {
-    pub center: Vec3,
+    pub center: Vec3A,
     pub radius: f32,
 }
 
 #[cfg(test)]
 mod test {
+    use glam::{const_vec3a, vec3a};
+
     use super::*;
 
-    fn generate_tri() -> Tri {
-        Tri {
-            p: [Vec3::new(-1.0, 5.0, 0.0), Vec3::new(2.0, 2.0, -3.0), Vec3::new(5.0, 5.0, 0.0)],
-        }
-    }
+    const TRI: Tri = Tri {
+        p: [const_vec3a!([-1.0, 5.0, 0.0]), const_vec3a!([2.0, 2.0, -3.0]), const_vec3a!([5.0, 5.0, 0.0])],
+    };
 
-    fn generate_sphere() -> Sphere {
-        Sphere {
-            center: Vec3::new(1.0, 0.0, 1.0),
-            radius: 2.0,
-        }
-    }
+    const SPHERE: Sphere = Sphere {
+        center: const_vec3a!([1.0, 0.0, 1.0]),
+        radius: 2.0,
+    };
 
-    fn generate_bounding_boxes() -> Vec<Aabb> {
-        vec![
-            Aabb {
-                min: Vec3::new(-0.5, -2.0, -0.5),
-                max: Vec3::new(0.5, 2.0, 0.5),
-            },
-            Aabb {
-                min: Vec3::new(-1.0, -1.0, -1.0),
-                max: Vec3::new(1.0, 1.0, 1.0),
-            },
-            Aabb {
-                min: Vec3::new(1.0, 1.0, 1.0),
-                max: Vec3::new(3.0, 3.0, 3.0),
-            },
-            Aabb {
-                min: Vec3::new(-4.0, -4.0, -4.0),
-                max: Vec3::new(-3.0, -3.0, -3.0),
-            },
-        ]
-    }
+    const BOUNDING_BOXES: &[Aabb] = &[
+        Aabb {
+            min: const_vec3a!([-0.5, -2.0, -0.5]),
+            max: const_vec3a!([0.5, 2.0, 0.5]),
+        },
+        Aabb {
+            min: const_vec3a!([-1.0, -1.0, -1.0]),
+            max: const_vec3a!([1.0, 1.0, 1.0]),
+        },
+        Aabb {
+            min: const_vec3a!([1.0, 1.0, 1.0]),
+            max: const_vec3a!([3.0, 3.0, 3.0]),
+        },
+        Aabb {
+            min: const_vec3a!([-4.0, -4.0, -4.0]),
+            max: const_vec3a!([-3.0, -3.0, -3.0]),
+        },
+    ];
 
     #[test]
     fn tri_sphere_intersect() {
-        let tri = generate_tri();
         {
             let sphere = Sphere {
-                center: Vec3::new(2.0, 4.0, -1.0),
+                center: vec3a(2.0, 4.0, -1.0),
                 radius: 0.5,
             };
 
-            assert!(tri.intersect_sphere(&sphere));
+            assert!(TRI.intersect_sphere(&sphere));
         }
         {
             let sphere = Sphere {
-                center: Vec3::new(-1.0, 5.0, 0.0),
+                center: vec3a(-1.0, 5.0, 0.0),
                 radius: 0.5,
             };
 
-            assert!(tri.intersect_sphere(&sphere));
+            assert!(TRI.intersect_sphere(&sphere));
         }
     }
 
     #[test]
     fn tri_sphere_not_intersect() {
-        let tri = generate_tri();
         {
             let sphere = Sphere {
-                center: Vec3::new(2.0, 2.0, 2.0),
+                center: Vec3A::splat(2.0),
                 radius: 1.0,
             };
 
-            assert!(!tri.intersect_sphere(&sphere));
+            assert!(!TRI.intersect_sphere(&sphere));
         }
         {
             let sphere = Sphere {
-                center: Vec3::new(-2.0, -2.0, -2.0),
+                center: Vec3A::splat(-2.0),
                 radius: 1.0,
             };
 
-            assert!(!tri.intersect_sphere(&sphere));
+            assert!(!TRI.intersect_sphere(&sphere));
         }
     }
 
     #[test]
     fn aabb_sphere_intersect() {
-        let sphere = generate_sphere();
-
         {
             let aabb = Aabb {
-                min: Vec3::new(2.0, 1.0, 2.0),
-                max: Vec3::new(4.0, 3.0, 4.0),
+                min: vec3a(2.0, 1.0, 2.0),
+                max: vec3a(4.0, 3.0, 4.0),
             };
 
-            assert!(aabb.intersect_sphere(&sphere));
+            assert!(aabb.intersect_sphere(&SPHERE));
         }
         {
             let aabb = Aabb {
-                min: Vec3::new(0.0, -1.0, 0.0),
-                max: Vec3::new(1.0, 0.0, 1.0),
+                min: vec3a(0.0, -1.0, 0.0),
+                max: vec3a(1.0, 0.0, 1.0),
             };
 
-            assert!(aabb.intersect_sphere(&sphere));
+            assert!(aabb.intersect_sphere(&SPHERE));
         }
         {
             let aabb = Aabb {
-                min: Vec3::new(-5.0, -5.0, -5.0),
-                max: Vec3::new(5.0, 5.0, 5.0),
+                min: Vec3A::splat(-5.0),
+                max: Vec3A::splat(5.0),
             };
 
-            assert!(aabb.intersect_sphere(&sphere));
+            assert!(aabb.intersect_sphere(&SPHERE));
         }
     }
 
     #[test]
     fn aabb_sphere_not_intersect() {
-        let sphere = generate_sphere();
-
         let aabb = Aabb {
-            min: Vec3::new(-2.0, -2.0, -2.0),
-            max: Vec3::new(-1.0, -1.0, -1.0),
+            min: Vec3A::splat(-2.0),
+            max: Vec3A::splat(-1.0),
         };
 
-        assert!(!aabb.intersect_sphere(&sphere));
+        assert!(!aabb.intersect_sphere(&SPHERE));
     }
 
     #[test]
     fn aabb_aabb_intersect() {
-        let bounding_boxes = generate_bounding_boxes();
-
         // Test for intersection with itself
-        assert!(bounding_boxes[0].intersect_self(&bounding_boxes[0]));
-        assert!(bounding_boxes[1].intersect_self(&bounding_boxes[1]));
-        assert!(bounding_boxes[2].intersect_self(&bounding_boxes[2]));
-        assert!(bounding_boxes[3].intersect_self(&bounding_boxes[3]));
+        assert!(BOUNDING_BOXES[0].intersect_self(&BOUNDING_BOXES[0]));
+        assert!(BOUNDING_BOXES[1].intersect_self(&BOUNDING_BOXES[1]));
+        assert!(BOUNDING_BOXES[2].intersect_self(&BOUNDING_BOXES[2]));
+        assert!(BOUNDING_BOXES[3].intersect_self(&BOUNDING_BOXES[3]));
 
         // Test for intersection with other bounding boxes
-        assert!(bounding_boxes[0].intersect_self(&bounding_boxes[1]));
-        assert!(bounding_boxes[1].intersect_self(&bounding_boxes[0]));
-        assert!(bounding_boxes[1].intersect_self(&bounding_boxes[2]));
-        assert!(bounding_boxes[2].intersect_self(&bounding_boxes[1]));
+        assert!(BOUNDING_BOXES[0].intersect_self(&BOUNDING_BOXES[1]));
+        assert!(BOUNDING_BOXES[1].intersect_self(&BOUNDING_BOXES[0]));
+        assert!(BOUNDING_BOXES[1].intersect_self(&BOUNDING_BOXES[2]));
+        assert!(BOUNDING_BOXES[2].intersect_self(&BOUNDING_BOXES[1]));
     }
 
     #[test]
     fn aabb_aabb_not_intersect() {
-        let bounding_boxes = generate_bounding_boxes();
-
-        assert!(!bounding_boxes[0].intersect_self(&bounding_boxes[2]));
-        assert!(!bounding_boxes[0].intersect_self(&bounding_boxes[3]));
-        assert!(!bounding_boxes[1].intersect_self(&bounding_boxes[3]));
-        assert!(!bounding_boxes[2].intersect_self(&bounding_boxes[0]));
-        assert!(!bounding_boxes[2].intersect_self(&bounding_boxes[3]));
-        assert!(!bounding_boxes[3].intersect_self(&bounding_boxes[0]));
-        assert!(!bounding_boxes[3].intersect_self(&bounding_boxes[1]));
-        assert!(!bounding_boxes[3].intersect_self(&bounding_boxes[2]));
+        assert!(!BOUNDING_BOXES[0].intersect_self(&BOUNDING_BOXES[2]));
+        assert!(!BOUNDING_BOXES[0].intersect_self(&BOUNDING_BOXES[3]));
+        assert!(!BOUNDING_BOXES[1].intersect_self(&BOUNDING_BOXES[3]));
+        assert!(!BOUNDING_BOXES[2].intersect_self(&BOUNDING_BOXES[0]));
+        assert!(!BOUNDING_BOXES[2].intersect_self(&BOUNDING_BOXES[3]));
+        assert!(!BOUNDING_BOXES[3].intersect_self(&BOUNDING_BOXES[0]));
+        assert!(!BOUNDING_BOXES[3].intersect_self(&BOUNDING_BOXES[1]));
+        assert!(!BOUNDING_BOXES[3].intersect_self(&BOUNDING_BOXES[2]));
     }
 }

--- a/src/simulation/geometry.rs
+++ b/src/simulation/geometry.rs
@@ -154,3 +154,157 @@ pub struct Sphere {
     pub center: Vec3,
     pub radius: f32,
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn generate_tri() -> Tri {
+        Tri {
+            p: [Vec3::new(-1.0, 5.0, 0.0), Vec3::new(2.0, 2.0, -3.0), Vec3::new(5.0, 5.0, 0.0)],
+        }
+    }
+
+    fn generate_sphere() -> Sphere {
+        Sphere {
+            center: Vec3::new(1.0, 0.0, 1.0),
+            radius: 2.0,
+        }
+    }
+
+    fn generate_bounding_boxes() -> Vec<Aabb> {
+        vec![
+            Aabb {
+                min: Vec3::new(-0.5, -2.0, -0.5),
+                max: Vec3::new(0.5, 2.0, 0.5),
+            },
+            Aabb {
+                min: Vec3::new(-1.0, -1.0, -1.0),
+                max: Vec3::new(1.0, 1.0, 1.0),
+            },
+            Aabb {
+                min: Vec3::new(1.0, 1.0, 1.0),
+                max: Vec3::new(3.0, 3.0, 3.0),
+            },
+            Aabb {
+                min: Vec3::new(-4.0, -4.0, -4.0),
+                max: Vec3::new(-3.0, -3.0, -3.0),
+            },
+        ]
+    }
+
+    #[test]
+    fn tri_sphere_intersect() {
+        let tri = generate_tri();
+        {
+            let sphere = Sphere {
+                center: Vec3::new(2.0, 4.0, -1.0),
+                radius: 0.5,
+            };
+
+            assert!(tri.intersect_sphere(&sphere));
+        }
+        {
+            let sphere = Sphere {
+                center: Vec3::new(-1.0, 5.0, 0.0),
+                radius: 0.5,
+            };
+
+            assert!(tri.intersect_sphere(&sphere));
+        }
+    }
+
+    #[test]
+    fn tri_sphere_not_intersect() {
+        let tri = generate_tri();
+        {
+            let sphere = Sphere {
+                center: Vec3::new(2.0, 2.0, 2.0),
+                radius: 1.0,
+            };
+
+            assert!(!tri.intersect_sphere(&sphere));
+        }
+        {
+            let sphere = Sphere {
+                center: Vec3::new(-2.0, -2.0, -2.0),
+                radius: 1.0,
+            };
+
+            assert!(!tri.intersect_sphere(&sphere));
+        }
+    }
+
+    #[test]
+    fn aabb_sphere_intersect() {
+        let sphere = generate_sphere();
+
+        {
+            let aabb = Aabb {
+                min: Vec3::new(2.0, 1.0, 2.0),
+                max: Vec3::new(4.0, 3.0, 4.0),
+            };
+
+            assert!(aabb.intersect_sphere(&sphere));
+        }
+        {
+            let aabb = Aabb {
+                min: Vec3::new(0.0, -1.0, 0.0),
+                max: Vec3::new(1.0, 0.0, 1.0),
+            };
+
+            assert!(aabb.intersect_sphere(&sphere));
+        }
+        {
+            let aabb = Aabb {
+                min: Vec3::new(-5.0, -5.0, -5.0),
+                max: Vec3::new(5.0, 5.0, 5.0),
+            };
+
+            assert!(aabb.intersect_sphere(&sphere));
+        }
+    }
+
+    #[test]
+    fn aabb_sphere_not_intersect() {
+        let sphere = generate_sphere();
+
+        let aabb = Aabb {
+            min: Vec3::new(-2.0, -2.0, -2.0),
+            max: Vec3::new(-1.0, -1.0, -1.0),
+        };
+
+        assert!(!aabb.intersect_sphere(&sphere));
+    }
+
+    #[test]
+    fn aabb_aabb_intersect() {
+        let bounding_boxes = generate_bounding_boxes();
+
+        // Test for intersection with itself
+        assert!(bounding_boxes[0].intersect_self(&bounding_boxes[0]));
+        assert!(bounding_boxes[1].intersect_self(&bounding_boxes[1]));
+        assert!(bounding_boxes[2].intersect_self(&bounding_boxes[2]));
+        assert!(bounding_boxes[3].intersect_self(&bounding_boxes[3]));
+
+        // Test for intersection with other bounding boxes
+        assert!(bounding_boxes[0].intersect_self(&bounding_boxes[1]));
+        assert!(bounding_boxes[1].intersect_self(&bounding_boxes[0]));
+        assert!(bounding_boxes[1].intersect_self(&bounding_boxes[2]));
+        assert!(bounding_boxes[2].intersect_self(&bounding_boxes[1]));
+    }
+
+    #[test]
+    fn aabb_aabb_not_intersect() {
+        let bounding_boxes = generate_bounding_boxes();
+
+        assert!(!bounding_boxes[0].intersect_self(&bounding_boxes[2]));
+        assert!(!bounding_boxes[0].intersect_self(&bounding_boxes[3]));
+        assert!(!bounding_boxes[1].intersect_self(&bounding_boxes[3]));
+        assert!(!bounding_boxes[2].intersect_self(&bounding_boxes[0]));
+        assert!(!bounding_boxes[2].intersect_self(&bounding_boxes[3]));
+        assert!(!bounding_boxes[3].intersect_self(&bounding_boxes[0]));
+        assert!(!bounding_boxes[3].intersect_self(&bounding_boxes[1]));
+        assert!(!bounding_boxes[3].intersect_self(&bounding_boxes[2]));
+    }
+}

--- a/src/simulation/morton.rs
+++ b/src/simulation/morton.rs
@@ -1,9 +1,10 @@
+use glam::Vec3A;
+
 use super::geometry::Aabb;
-use vvec3::Vec3;
 
 pub struct Morton {
-    pub offset: Vec3,
-    pub scale: Vec3,
+    pub offset: Vec3A,
+    pub scale: Vec3A,
 }
 
 impl Morton {
@@ -32,7 +33,7 @@ impl Morton {
         x
     }
 
-    pub fn encode(u: Vec3) -> u64 {
+    pub fn encode(u: Vec3A) -> u64 {
         // These should actually be 21 bits, but there's no u21 type and the final type is u64 (21 bits * 3 = 63 bits)
         let x = u.x as u32;
         let y = u.y as u32;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,10 +1,10 @@
+use glam::{vec3a, Vec3A};
 use rand::Rng;
 use rl_ball_sym::simulation::ball::Ball;
 use rl_ball_sym::simulation::game::Game;
 use rl_ball_sym::simulation::geometry::Aabb;
 use rl_ball_sym::simulation::morton::Morton;
 use rl_ball_sym::{load_dropshot, load_hoops, load_soccar, load_soccar_throwback};
-use vvec3::Vec3;
 
 static mut GAME_0: Option<Game> = None;
 
@@ -24,15 +24,15 @@ fn init() {
 #[test]
 fn morton() {
     let global_box = Aabb {
-        min: Vec3::new(-4096., -5120., 0.),
-        max: Vec3::new(4096., 5120., 2044.),
+        min: vec3a(-4096., -5120., 0.),
+        max: vec3a(4096., 5120., 2044.),
     };
 
     let morton = Morton::from(&global_box);
 
     let box_ = Aabb {
-        min: Vec3::new(-4095., -5119., 1.),
-        max: Vec3::new(-4094., -5118., 2.),
+        min: vec3a(-4095., -5119., 1.),
+        max: vec3a(-4094., -5118., 2.),
     };
 
     // let code = morton.get_code(&box_);
@@ -195,7 +195,7 @@ fn basic_predict() {
     assert_eq!(game.ball.radius as i64, 91);
     assert_eq!(game.ball.collision_radius as i64, 93);
 
-    game.ball.update(0.098145, Vec3::new(-2294.5247, 1684.136, 317.17673), Vec3::new(1273.7537, -39.792305, 763.2827), Vec3::new(2.3894, -0.8755, 3.8078));
+    game.ball.update(0.098145, vec3a(-2294.5247, 1684.136, 317.17673), vec3a(1273.7537, -39.792305, 763.2827), vec3a(2.3894, -0.8755, 3.8078));
 
     let time = 60.; // 1 minute, lol
     let ball_prediction = Ball::get_ball_prediction_struct_for_time(&mut game, &time);
@@ -213,7 +213,7 @@ fn basic_predict() {
     dbg!(game.collision_mesh.global_box);
 
     for _ in 0..iters {
-        game.ball.update(0., Vec3::new(rng.gen_range(-3900.0..3900.), rng.gen_range(-5000.0..5000.), rng.gen_range(100.0..1900.)), Vec3::new(rng.gen_range(-2000.0..2000.), rng.gen_range(-2000.0..2000.), rng.gen_range(-2000.0..2000.)), Vec3::new(rng.gen_range(-3.0..3.), rng.gen_range(-3.0..3.), rng.gen_range(-3.0..3.)));
+        game.ball.update(0., vec3a(rng.gen_range(-3900.0..3900.), rng.gen_range(-5000.0..5000.), rng.gen_range(100.0..1900.)), vec3a(rng.gen_range(-2000.0..2000.), rng.gen_range(-2000.0..2000.), rng.gen_range(-2000.0..2000.)), vec3a(rng.gen_range(-3.0..3.), rng.gen_range(-3.0..3.), rng.gen_range(-3.0..3.)));
 
         let ball_prediction = Ball::get_ball_prediction_struct(&mut game);
 
@@ -292,19 +292,13 @@ fn predict_throwback_soccar() {
 fn check_for_nans() {
     let mut game = load_soccar();
 
-    game.ball.update(0., Vec3::new(0., 0., 100.), Vec3::default(), Vec3::default());
+    game.ball.update(0., vec3a(0., 0., 100.), Vec3A::ZERO, Vec3A::ZERO);
 
     let ball_prediction = Ball::get_ball_prediction_struct(&mut game);
 
     for slice in ball_prediction.slices {
-        assert!(slice.location.x.is_finite());
-        assert!(slice.location.y.is_finite());
-        assert!(slice.location.z.is_finite());
-        assert!(slice.velocity.x.is_finite());
-        assert!(slice.velocity.y.is_finite());
-        assert!(slice.velocity.z.is_finite());
-        assert!(slice.angular_velocity.x.is_finite());
-        assert!(slice.angular_velocity.y.is_finite());
-        assert!(slice.angular_velocity.z.is_finite());
+        assert!(slice.location.is_finite());
+        assert!(slice.velocity.is_finite());
+        assert!(slice.angular_velocity.is_finite());
     }
 }


### PR DESCRIPTION
Speed up `get_ball_prediction*` methods. Load times are slightly longer, but that should be an acceptable trade off for the improved prediction times as loading should only happen once at initialization.

Benchmark results on a Ryzen 7 3700X are as follows:
```
init                    time:   [120.42 us 120.54 us 120.66 us]                 
                        change: [-38.741% -38.204% -37.697%] (p = 0.00 < 0.05)

load_soccar             time:   [1.8426 ms 1.8499 ms 1.8615 ms]                         
                        change: [+14.897% +15.325% +15.851%] (p = 0.00 < 0.05)

load_hoops              time:   [4.2667 ms 4.2926 ms 4.3260 ms]                        
                        change: [+17.305% +18.044% +19.001%] (p = 0.00 < 0.05)

load_dropshot           time:   [643.56 us 644.23 us 644.93 us]                          
                        change: [+1.3607% +1.5823% +1.7859%] (p = 0.00 < 0.05)

get_ball_prediction_struct_for_time/8                                                                            
                        time:   [167.49 us 168.30 us 169.15 us]
                        change: [-36.448% -36.034% -35.623%] (p = 0.00 < 0.05)

get_ball_prediction/soccar                                                                            
                        time:   [130.33 us 130.66 us 131.03 us]
                        change: [-34.542% -33.956% -33.343%] (p = 0.00 < 0.05)

get_ball_prediction/hoops                                                                            
                        time:   [236.65 us 237.09 us 237.53 us]
                        change: [-34.569% -34.158% -33.763%] (p = 0.00 < 0.05)

get_ball_prediction/dropshot                                                                            
                        time:   [106.89 us 107.00 us 107.12 us]
                        change: [-43.871% -43.479% -43.108%] (p = 0.00 < 0.05)

get_ball_prediction/throwback                                                                            
                        time:   [46.233 ms 46.308 ms 46.392 ms]
                        change: [-16.628% -16.488% -16.338%] (p = 0.00 < 0.05)
```
