### PR TITLE
Remove redundant implementations of Default

### DIFF
--- a/src/simulation/ball.rs
+++ b/src/simulation/ball.rs
@@ -13,19 +13,10 @@ pub struct Ball {
     pub moi: f32,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct BallPrediction {
     pub num_slices: usize,
     pub slices: Vec<Ball>,
-}
-
-impl Default for BallPrediction {
-    fn default() -> Self {
-        Self {
-            num_slices: 0,
-            slices: Vec::new(),
-        }
-    }
 }
 
 impl Ball {

--- a/src/simulation/bvh.rs
+++ b/src/simulation/bvh.rs
@@ -3,7 +3,7 @@ use super::geometry::{Ray, Sphere};
 use super::morton::Morton;
 use std::boxed::Box;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct BvhNode {
     pub is_terminal: bool,
     pub box_: Aabb,
@@ -11,19 +11,6 @@ pub struct BvhNode {
     pub left: Option<Box<BvhNode>>,
     pub primitive: Option<Tri>,
     pub morton: Option<u64>,
-}
-
-impl Default for BvhNode {
-    fn default() -> Self {
-        Self {
-            is_terminal: false,
-            box_: Aabb::default(),
-            right: None,
-            left: None,
-            primitive: None,
-            morton: None,
-        }
-    }
 }
 
 impl BvhNode {

--- a/src/simulation/game.rs
+++ b/src/simulation/game.rs
@@ -3,19 +3,9 @@ use glam::Vec3A;
 use super::ball::Ball;
 use super::bvh::Bvh;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Game {
     pub gravity: Vec3A,
     pub collision_mesh: Bvh,
     pub ball: Ball,
-}
-
-impl Default for Game {
-    fn default() -> Self {
-        Self {
-            gravity: Vec3A::default(),
-            collision_mesh: Bvh::default(),
-            ball: Ball::default(),
-        }
-    }
 }

--- a/src/simulation/geometry.rs
+++ b/src/simulation/geometry.rs
@@ -53,19 +53,10 @@ impl Tri {
 
 // AABB stands for "Axis-Aligned Bounding Boxes"
 // Learn more here: https://developer.nvidia.com/blog/thinking-parallel-part-i-collision-detection-gpu/
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Aabb {
     pub min: Vec3A,
     pub max: Vec3A,
-}
-
-impl Default for Aabb {
-    fn default() -> Self {
-        Self {
-            min: Vec3A::default(),
-            max: Vec3A::default(),
-        }
-    }
 }
 
 impl Aabb {
@@ -117,19 +108,10 @@ impl From<&'_ Sphere> for Aabb {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Int2 {
     pub x: i32,
     pub y: i32,
-}
-
-impl Default for Int2 {
-    fn default() -> Self {
-        Self {
-            x: 0,
-            y: 0,
-        }
-    }
 }
 
 // endpoint is start + direction

--- a/src/simulation/mesh.rs
+++ b/src/simulation/mesh.rs
@@ -4,19 +4,10 @@ use super::geometry::Tri;
 
 use crate::linear_algebra::math::dot;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Mesh {
     pub ids: Vec<i32>,
     pub vertices: Vec<f32>,
-}
-
-impl Default for Mesh {
-    fn default() -> Self {
-        Self {
-            ids: Vec::new(),
-            vertices: Vec::new(),
-        }
-    }
 }
 
 impl Mesh {


### PR DESCRIPTION
By using `#[derive(Default)]` we can omit these clippy lint warnings.